### PR TITLE
Fix replacement of values in kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     keywords='stackexchange',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*', 'test']),
     version='0.1.12',
-    install_requires=['requests'],
+    install_requires=['requests', 'six'],
     tests_require=['mock'],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Related to issue #36.

Check if the value is a string, an iterable, or other, in that order (order is important, as a string is also an iterable). Then do the replacements.

```python
>>> from stackapi import StackAPI
>>> site = StackAPI('stackoverflow')
>>> tag = 'java'
>>> period = 'month'
>>> site.fetch('tags/{tag}/top-answerers/{period}', tag=tag, period=period)
{'backoff': 0, 'has_more': False, 'page': 1, 'quota_max': 300, 'quota_remaining': 300, 'total': 0, 'items': [{'user': {'reputation': 8583, 'user_id': 10819573, 'user_type': 'registered', 'profile_im ...
```