### PR TITLE
Updated install.rst

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -22,7 +22,7 @@ Source Code
 StackAPI is developed on GitHub where the code is
 `always available <https://github.com/AWegnerGitHub/stackapi>`_.
 
-You can close the repository::
+You can clone the repository::
 
     $ git clone git://github.com/AWegnerGitHub/stackapi.git
 


### PR DESCRIPTION
Original sentence with misspelling: "You can close the repository::" at line number 25

Corrected sentence with "clone": You can clone the repository::