### PR TITLE
Make base_url configurable

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,7 +10,7 @@ Patches and Suggestions
 ```````````````````````
 
 `@ArtOfCode- <https://github.com/ArtOfCode->`_
-`@bgrnwdvg - <https://github.com/bgrnwdvg>`
+`@bgrnwdvg - <https://github.com/bgrnwdvg>`_
 
 
 :ref:`Contribute <contributing>` a feature and get your name here!

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,6 +10,7 @@ Patches and Suggestions
 ```````````````````````
 
 `@ArtOfCode- <https://github.com/ArtOfCode->`_
+`@bgrnwdvg - <https://github.com/bgrnwdvg>`
 
 
 :ref:`Contribute <contributing>` a feature and get your name here!

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ This library has support for:
    all the results into a single response.
 -  Throws exceptions returned by the API for easier troubleshooting.
 -  Utilizes `Requests <http://docs.python-requests.org/>`__.
+-  `Stack Overflow for Teams <https://stackoverflow.co/teams/>`_ API
 
 
 Example usage:

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -36,6 +36,23 @@ default filter the API provides. The value passed to
 If you are looking for more information on how to tailor the results of your
 queries. Take a look at the :ref:`Advanced Usage <advanced>` examples.
 
+.. _enterprise-usage:
+
+Using with Stack Overflow for Teams
+-----------------------------------
+
+When using with Stack Overflow for Teams, the client has to be instantiated a
+bit differently::
+
+    >>> SITE = StackAPI('mystacksite.com', base_url='https://mystacksite.com/api', key='mykey')
+
+The ``name`` argument needs to match the ``api_site_parameter`` key from the
+``sites`` endpoint. This may be the domain (e.g. ``mystacksite.com``) or the
+name of the site (e.g. ``MyCompany Stack Overflow``). You'll most likely need to 
+`create an API key <https://stackoverflowteams.help/en/articles/4385859-stack-overflow-for-teams-api#create-a-pat>`_
+and pass that in to the ``key`` argument. Otherwise, everything else should
+function the same.
+
 .. _change-num-results:
 
 Change number of results

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.2.0
+current_version = 0.3.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license='MIT',
     keywords='stackexchange',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*', 'test']),
-    version='0.2.0',
+    version='0.3.0',
     install_requires=['requests', 'six'],
     tests_require=['mock'],
     classifiers=[

--- a/stackapi/stackapi.py
+++ b/stackapi/stackapi.py
@@ -28,7 +28,7 @@ class StackAPIError(Exception):
 
 
 class StackAPI(object):
-    def __init__(self, name=None, version="2.2", **kwargs):
+    def __init__(self, name=None, version="2.2", base_url="https://api.stackexchange.com", **kwargs):
         """
         The object used to interact with the Stack Exchange API
 
@@ -38,6 +38,8 @@ class StackAPI(object):
             Network.
         :param version: (float) **(Required)** The version of the API you are connecting to.
             The default of ``2.2`` is the current version
+        :param base_url: (string) (optional) The base URL for the Stack Exchange API.
+            The default is https://api.stackexchange.com
         :param proxy: (dict) (optional) A dictionary of http and https proxy locations
             Example:
 
@@ -68,7 +70,7 @@ class StackAPI(object):
         self._version = version
         self._previous_call = None
 
-        self._base_url = 'https://api.stackexchange.com/{}/'.format(version)
+        self._base_url = '{}/{}/'.format(base_url, version)
         sites = self.fetch('sites', filter='!*L1*AY-85YllAr2)', pagesize=1000)
         for s in sites['items']:
             if name == s['api_site_parameter']:

--- a/tests/test_stackapi.py
+++ b/tests/test_stackapi.py
@@ -80,7 +80,7 @@ class Test_StackAPI(unittest.TestCase):
     @patch('stackapi.StackAPI.fetch', fake_stackoverflow_exists)
     def test_override_base_url(self):
         """Testing that the base_url can be overridden"""
-        self.assertEqual(StackAPI('stackoverflow',version="2.3",base_url="https://api.mystacksite.com")._base_url, "https://api.mystacksite.com/2.3/")
+        self.assertEqual(StackAPI(name='stackoverflow',version="2.3",base_url="https://mystacksite.com/api",key="foo")._base_url, "https://mystacksite.com/api/2.3/",)
 
 if __name__ == '__main__':
     import sys

--- a/tests/test_stackapi.py
+++ b/tests/test_stackapi.py
@@ -72,6 +72,15 @@ class Test_StackAPI(unittest.TestCase):
         self.assertEqual(cm.exception.error, 400)
         self.assertEqual(cm.exception.code, 'bad_parameter')
 
+    @patch('stackapi.StackAPI.fetch', fake_stackoverflow_exists)
+    def test_default_base_url(self):
+        """Testing that the base_url uses the default value"""
+        self.assertEqual(StackAPI('stackoverflow')._base_url, "https://api.stackexchange.com/2.2/")
+
+    @patch('stackapi.StackAPI.fetch', fake_stackoverflow_exists)
+    def test_override_base_url(self):
+        """Testing that the base_url can be overridden"""
+        self.assertEqual(StackAPI('stackoverflow',version="2.3",base_url="https://api.mystacksite.com")._base_url, "https://api.mystacksite.com/2.3/")
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
This PR makes the `base_url` configurable. Stack Overflow released an enterprise version of Stack Overflow called [Stack Overflow For Teams](https://stackoverflow.co/teams/). This change would allow users who are using the enterprise version to set the `base_url` for their instance.