### PR TITLE
Add a (missing?) backtick character for inline code

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -77,7 +77,7 @@ a score of at least 20 and are tagged ``python``::
 
 We can see that a single question matched our criteria.
 
-**Note**: In the above example, we passed a timestamp value to the ``fromdate`
+**Note**: In the above example, we passed a timestamp value to the ``fromdate``
 and ``todate`` parameters. StackAPI will also allow you to pass in 
 ``datetime`` objects and automatically perform this conversion for you.
 


### PR DESCRIPTION
Note: I have _not_ ran the tests for the code, as this is a documentation change. Still, if there are tests I should run for the docs, let me know, and I can try.

Currently, part of [the advanced page](https://stackapi.readthedocs.io/en/latest/user/advanced.html) renders like this:
![image](https://github.com/AWegnerGitHub/stackapi/assets/45187468/ba6471d5-50ee-4826-b8ca-5577d2d51cc8)

This PR attempts to fix that so it displays correctly. I'm not familiar with restructuredtext, but based on [this](https://github.com/ralsina/rst-cheatsheet/blob/master/rst-cheatsheet.rst), I _think_ this change is correct.